### PR TITLE
PLM-11: Adding label on map feature implemented

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,26 +1,30 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {Tabs} from 'expo-router';
+import {Provider} from "react-redux";
+import {store} from "@/redux/store";
 
 export default function TabLayout() {
     return (
-        <Tabs screenOptions={{tabBarActiveTintColor: 'blue'}}>
-            <Tabs.Screen
-                name="index"
-                options={{
-                    title: 'Home',
-                    tabBarIcon: ({color}) => <FontAwesome size={28} name="home" color={color}/>,
-                    headerShown: false
-                }}
-            />
-            <Tabs.Screen
-                name="addLocation"
-                options={{
-                    title: 'Add Location',
-                    tabBarIcon: ({color}) => <FontAwesome size={28} name="plus" color={color}/>,
-                    headerShown: false
+        <Provider store={store}>
+            <Tabs screenOptions={{tabBarActiveTintColor: 'blue'}}>
+                <Tabs.Screen
+                    name="index"
+                    options={{
+                        title: 'Home',
+                        tabBarIcon: ({color}) => <FontAwesome size={28} name="home" color={color}/>,
+                        headerShown: false,
+                    }}
+                />
+                <Tabs.Screen
+                    name="addLocation"
+                    options={{
+                        title: 'Add Location',
+                        tabBarIcon: ({color}) => <FontAwesome size={28} name="plus" color={color}/>,
+                        headerShown: false
 
-                }}
-            />
-        </Tabs>
+                    }}
+                />
+            </Tabs>
+        </Provider>
     );
 }

--- a/app/(tabs)/addLocation.tsx
+++ b/app/(tabs)/addLocation.tsx
@@ -1,5 +1,5 @@
-import AddLocationScreen from "@/screens/addLocation";
+import AddLocationScreen from '@/screens/addLocation';
 
-export default function AddLocation() {
+export default function AddLocation () {
     return <AddLocationScreen />
 }

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -1,0 +1,42 @@
+import {Modal, Pressable, Text, TextInput, TouchableOpacity, View} from "react-native";
+import styles from "./styles";
+import React from "react";
+
+interface CustomModalProps {
+    isModalOpen: boolean,
+    setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>,
+    label: string,
+    setLabel: React.Dispatch<React.SetStateAction<string>>,
+    error: string | null,
+    onPress: () => void
+}
+
+export default function CustomModal({
+                                        isModalOpen,
+                                        setIsModalOpen,
+                                        label,
+                                        setLabel,
+                                        error,
+                                        onPress
+                                    }: CustomModalProps) {
+    return (
+        <Modal visible={isModalOpen} transparent={true} onRequestClose={() => setIsModalOpen(false)}
+               animationType={'fade'}>
+            <TouchableOpacity style={{width: "100%", height: "100%"}} onPress={() => setIsModalOpen(false)}>
+                <View style={styles.centeredView}>
+                    <View style={styles.modalView}>
+                        <Text style={styles.modalText}>Give this place a label</Text>
+                        <TextInput value={label} placeholder='label name' onChangeText={text => setLabel(text)}
+                                   style={styles.labelInput}/>
+                        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+                        <Pressable
+                            style={[styles.button, styles.buttonClose]}
+                            onPress={onPress}>
+                            <Text style={styles.textStyle}>Save</Text>
+                        </Pressable>
+                    </View>
+                </View>
+            </TouchableOpacity>
+        </Modal>
+    )
+}

--- a/components/modal/styles.tsx
+++ b/components/modal/styles.tsx
@@ -1,0 +1,58 @@
+import {StyleSheet} from 'react-native';
+
+const styles = StyleSheet.create({
+    centeredView: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    modalView: {
+        backgroundColor: 'white',
+        borderRadius: 20,
+        padding: 35,
+        alignItems: 'center',
+        shadowColor: '#000',
+        shadowOffset: {
+            width: 0,
+            height: 2,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+        elevation: 5,
+        width: '80%',
+    },
+    button: {
+        borderRadius: 10,
+        padding: 10,
+        elevation: 2,
+    },
+    buttonOpen: {
+        backgroundColor: '#F194FF',
+    },
+    buttonClose: {
+        backgroundColor: '#2196F3',
+    },
+    textStyle: {
+        color: 'white',
+        fontWeight: 'bold',
+        textAlign: 'center',
+    },
+    modalText: {
+        marginBottom: 15,
+        textAlign: 'center',
+    },
+    labelInput: {
+        marginBottom: 15,
+        borderWidth: 1,
+        padding: 10,
+        borderRadius: 10,
+        minWidth: '50%',
+        maxWidth: '50%',
+    },
+    errorText: {
+        color: 'red',
+        marginBottom: 15,
+    },
+})
+
+export default styles

--- a/redux/slices/locations.ts
+++ b/redux/slices/locations.ts
@@ -2,7 +2,8 @@ import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
 interface LocationInterface {
     name: string;
-    coordinates: string;
+    latitude: number;
+    longitude: number;
     radius: number;
     tasks: string[];
 }

--- a/screens/addLocation/index.tsx
+++ b/screens/addLocation/index.tsx
@@ -1,13 +1,23 @@
 import React, {useEffect, useState} from 'react';
-import MapView, {PROVIDER_GOOGLE} from 'react-native-maps';
-import {ActivityIndicator, SafeAreaView, View} from 'react-native';
+import MapView, {Circle, PROVIDER_GOOGLE, Region} from 'react-native-maps';
+import {ActivityIndicator, SafeAreaView, View, Text, Pressable, TextInput} from 'react-native';
 import {GooglePlacesAutocomplete} from "react-native-google-places-autocomplete";
 import * as Location from 'expo-location';
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {addLocation} from "@/redux/slices/locations";
+import {useAppDispatch, useAppSelector} from "@/hooks/redux";
 import styles from './styles';
+import CustomModal from "@/components/modal";
 
 export default function AddLocationScreen() {
-    const [searchLocation, setSearchLocation] = React.useState<{ latitude: number; longitude: number } | null>(null);
-    const [currentLocation, setcurrentLocation] = useState<Location.LocationObject>();
+    const dispatch = useAppDispatch();
+    const locationError = useAppSelector(state => state.locations.error)
+    const [searchLocation, setSearchLocation] = useState<Region>();
+    const [currentLocation, setCurrentLocation] = useState<Location.LocationObject>();
+    const [radius, setRadius] = useState(50);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [label, setLabel] = useState('');
+    const [saving, setSaving] = useState(false);
     const [errorMsg, setErrorMsg] = useState<string>();
 
     useEffect(() => {
@@ -19,31 +29,61 @@ export default function AddLocationScreen() {
             }
 
             let location = await Location.getCurrentPositionAsync({});
-            setcurrentLocation(location);
+            setCurrentLocation(location);
         })();
     }, []);
 
+    useEffect(() => {
+        if (saving && !locationError && isModalOpen) {
+            setIsModalOpen(false);
+            setSaving(false);
+        }
+    }, [saving, locationError, isModalOpen]);
+
+    const saveLocation = () => {
+        if (searchLocation) {
+            dispatch(addLocation({
+                name: label,
+                latitude: searchLocation.latitude,
+                longitude: searchLocation.longitude,
+                radius: radius,
+                tasks: []
+            }))
+            setSaving(true)
+        }
+    }
+
     return (
-        currentLocation ?
+        currentLocation && !errorMsg ?
             <SafeAreaView style={styles.container}>
                 <MapView
                     style={styles.map}
                     provider={PROVIDER_GOOGLE}
-                    region={{
-                        latitude: searchLocation ? searchLocation.latitude : currentLocation.coords.latitude,
-                        longitude: searchLocation ? searchLocation.longitude : currentLocation.coords.longitude,
-                        latitudeDelta: 0.001,
-                        longitudeDelta: 0.001
+                    initialRegion={{
+                        latitude: currentLocation.coords.latitude,
+                        longitude: currentLocation.coords.longitude,
+                        latitudeDelta: 0.002,
+                        longitudeDelta: 0.002
                     }}
-                />
-                <View style={styles.innerContainer}>
+                    region={searchLocation}
+                    onRegionChangeComplete={(region) => setSearchLocation(region)}
+                >
+                    <Circle center={{
+                        latitude: searchLocation?.latitude ?? currentLocation.coords.latitude,
+                        longitude: searchLocation?.longitude ?? currentLocation.coords.longitude,
+                    }}
+                            radius={radius}/>
+                </MapView>
+                <View style={styles.searchBar}>
                     <GooglePlacesAutocomplete
                         placeholder='Search'
                         fetchDetails={true}
                         onPress={(_, details) => {
                             if (details) setSearchLocation({
                                 latitude: details.geometry.location.lat,
-                                longitude: details.geometry.location.lng
+                                longitude: details.geometry.location.lng,
+                                latitudeDelta: 0.002,
+                                longitudeDelta: 0.002
                             });
                         }}
                         query={{
@@ -52,10 +92,36 @@ export default function AddLocationScreen() {
                         }}
                     />
                 </View>
+                <View style={styles.radiusBar}>
+                    <Pressable style={styles.radiusBarTopContainer}
+                               onPress={() => setIsModalOpen(true)}>
+                        <Text>Save Location</Text>
+                    </Pressable>
+                    <View style={styles.radiusBarBottomContainer}>
+                        <Pressable
+                            style={pressed => pressed.pressed ? [styles.radiusBarIconContainer, {opacity: 0.5}] : styles.radiusBarIconContainer}
+                            onPress={() => setRadius(radius > 50 ? radius - 50 : 50)}>
+                            <FontAwesome name='minus' size={28} color='black'/>
+                        </Pressable>
+                        <View style={styles.radiusBarTextContainer}>
+                            <TextInput value={String(radius)} inputMode='numeric'
+                                       onChangeText={text => setRadius(Number(text))}/><Text>meters</Text>
+                        </View>
+                        <Pressable style={styles.radiusBarIconContainer} onPress={() => setRadius(radius + 500)}>
+                            <FontAwesome name='plus' size={28} color='black'/>
+                        </Pressable>
+                    </View>
+                </View>
+                <CustomModal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} label={label}
+                             onPress={saveLocation} error={locationError} setLabel={setLabel}/>
             </SafeAreaView>
-            :
-            <SafeAreaView style={styles.center}>
-                <ActivityIndicator size={'large'}/>
-            </SafeAreaView>
+            : !errorMsg ?
+                <SafeAreaView style={styles.center}>
+                    <ActivityIndicator size={'large'}/>
+                </SafeAreaView>
+                :
+                <SafeAreaView style={styles.center}>
+                    <Text>{locationError}</Text>
+                </SafeAreaView>
     );
 }

--- a/screens/addLocation/styles.tsx
+++ b/screens/addLocation/styles.tsx
@@ -8,17 +8,52 @@ const styles = StyleSheet.create({
         width: '100%',
         height: '100%',
     },
-    innerContainer: {
+    searchBar: {
         position: 'absolute',
         top: '10%',
         width: '94%',
         marginHorizontal: '3%',
     },
+    radiusBar: {
+        position: 'absolute',
+        bottom: '2%',
+        width: '94%',
+        marginHorizontal: '3%',
+    },
+    radiusBarBottomContainer: {
+        paddingVertical: '3%',
+        backgroundColor: '#FF6500',
+        display: 'flex',
+        flexDirection: 'row',
+        borderRadius: 10
+    },
+    radiusBarTopContainer: {
+        width: '60%',
+        marginHorizontal: 'auto',
+        backgroundColor: '#FF6500',
+        display: 'flex',
+        justifyContent: "center",
+        alignItems: 'center',
+        paddingVertical: '5%',
+        borderTopRightRadius: 10,
+        borderTopLeftRadius: 10
+    },
     center: {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'center',
-    }
+    },
+    radiusBarIconContainer: {
+        display: 'flex',
+        flexGrow: 0.5,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    radiusBarTextContainer: {
+        flexGrow: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
 });
 
 export default styles

--- a/screens/home/index.tsx
+++ b/screens/home/index.tsx
@@ -1,10 +1,16 @@
 import {SafeAreaView, Text} from 'react-native';
+import {useAppSelector} from "@/hooks/redux";
 import styles from './styles'
 
-export default function HomeScreen() {
+export default function Index() {
+    const locations = useAppSelector(state => state.locations.locations);
+
     return (
         <SafeAreaView style={styles.container}>
             <Text>Home screen</Text>
+            {locations.map(location => (
+                <Text>{location.name}, {location.latitude}, {location.radius}</Text>
+            ))}
         </SafeAreaView>
     );
 }


### PR DESCRIPTION
### Description
User can now search or manually move map and then save a location with a custom radius to denote that as a labelled 'area'
### Related Tickets
- [PLM-11](https://placeminder.atlassian.net/browse/PLM-11)
### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have linked the related back-end PR (if applicable) [Link here](#).
### Dependencies
- [ ] My change requires changes to the following dependencies.
- [ ] I have verified that the new versions of these dependencies do not introduce breaking changes.
### Screenshots
<img width="373" alt="Screenshot 2024-10-02 at 6 08 38 pm" src="https://github.com/user-attachments/assets/d8496c5b-bfc7-4e85-86a4-ffad611ec018">
<img width="372" alt="Screenshot 2024-10-02 at 6 09 23 pm" src="https://github.com/user-attachments/assets/290957be-3c83-43fe-881b-fff9f7cc5ff7">
<img width="374" alt="Screenshot 2024-10-02 at 6 09 36 pm" src="https://github.com/user-attachments/assets/04f4592b-4e18-4660-9d7c-730b68a60c74">
<img width="358" alt="Screenshot 2024-10-02 at 6 09 56 pm" src="https://github.com/user-attachments/assets/7113ec93-fd04-44d4-9b04-977a62df5262">
###Notes
Last screenshot shows that errors are also handled. If the same name is used twice it throws an error.

[PLM-11]: https://placeminder.atlassian.net/browse/PLM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ